### PR TITLE
Scale and center visuals.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.prerendered/

--- a/MPLAnimator.py
+++ b/MPLAnimator.py
@@ -38,7 +38,7 @@ class Animator:
         if name == None:
             self.tmpdir = tempfile.TemporaryDirectory()
             self.dir = self.tmpdir.name
-            self.name = 'animator_'+self.dir
+            self.name = 'animator_' + self.dir
         else:
             self.dir = '.prerendered/' + name
             if not os.path.exists(self.dir):
@@ -46,7 +46,6 @@ class Animator:
 
         if setup_cb:
             setup_cb()
-
 
     def initUI(self):
         """Initialize the UI."""
@@ -78,7 +77,6 @@ class Animator:
         self.prerender_checkbox = QtWidgets.QCheckBox('Pre-rendered')
         self.layout.addWidget(self.prerender_checkbox)
 
-
     def setFrameCallback(self, frame_cb, max_frame):
         """Set frame-callback relevant attributes.
 
@@ -92,7 +90,6 @@ class Animator:
         self.max_frame = max_frame
         self.slider.setMaximum(max_frame - 1)
 
-
     def setClickCallback(self, click_cb):
         """Set click-callback relevant attributes.
 
@@ -101,7 +98,6 @@ class Animator:
 
         """
         self.click_cb = click_cb
-
 
     def prerender(self):
         """Prerender the animation."""
@@ -112,12 +108,10 @@ class Animator:
                 self.frame_cb(i)
                 plt.savefig('{}/{}.png'.format(self.dir, i))
 
-
     def handleCanvasClick(self, event: matplotlib.backend_bases.MouseEvent):
         """Unpack canvas click event to click callback function."""
         self.click_cb(**(event.__dict__))
         self.visualize()
-
 
     def visualize(self, i=None):
         """Update visualization for set frame.
@@ -141,7 +135,6 @@ class Animator:
                 self.stack.setCurrentWidget(self.canvas)
             self.frame_cb(i)
             self.canvas.draw()
-
 
     def clear(self):
         """Clear pre-rendered images."""

--- a/MPLAnimator.py
+++ b/MPLAnimator.py
@@ -61,6 +61,7 @@ class Animator:
         self.stack = QtWidgets.QStackedLayout()
         self.layout.addLayout(self.stack)
         self.label = QtWidgets.QLabel()
+        self.label.setAlignment(Qt.AlignCenter)
         self.stack.addWidget(self.label)
         self.fig = plt.figure()
         self.canvas = FigureCanvas(self.fig)

--- a/MPLAnimator.py
+++ b/MPLAnimator.py
@@ -134,7 +134,10 @@ class Animator:
             if self.stack.currentWidget() != self.label:
                 self.stack.setCurrentWidget(self.label)
             pm = QtGui.QPixmap('{}/{}.png'.format(self.dir, i))
+            pm = pm.scaled(self.label.width(), self.label.height(),
+                           Qt.KeepAspectRatio, Qt.SmoothTransformation)
             self.label.setPixmap(pm)
+            self.label.setMinimumSize(1, 1)  # Allow downsizing the window.
         else:
             if self.stack.currentWidget() != self.canvas:
                 self.stack.setCurrentWidget(self.canvas)

--- a/MPLAnimator.py
+++ b/MPLAnimator.py
@@ -151,15 +151,17 @@ class Animator:
         for file in os.listdir(self.dir):
             os.remove(self.dir + '/' + file)
 
-
-    def run(self, clear=False, prerendered=True, initialFrame=0):
+    def run(self, clear=False, prerendered=False, initialFrame=0):
         """Start the animator.
 
         The function will block and also start PyQt in the background.
 
         Args:
             clear (bool): Whether to clear potentially existing pre-rendered images.
-            prerendered (bool): Whether to use pre-rendered images. If there are already images saved, these are used.
+            prerendered (bool): Whether to use pre-rendered images.
+                If there are already images saved, these are used.
+                Turned off by default because resizing the window before pre-
+                rendering will give better quality results.
             initialFrame (int): Frame number to start the animation with.
 
         """

--- a/MPLAnimator.py
+++ b/MPLAnimator.py
@@ -110,7 +110,8 @@ class Animator:
 
     def handleCanvasClick(self, event: matplotlib.backend_bases.MouseEvent):
         """Unpack canvas click event to click callback function."""
-        self.click_cb(**(event.__dict__))
+        if hasattr(self, 'click') and self.click is not None:
+            self.click_cb(**(event.__dict__))
         self.visualize()
 
     def visualize(self, i=None):

--- a/MPLAnimator.py
+++ b/MPLAnimator.py
@@ -55,6 +55,7 @@ class Animator:
         self.w = QtWidgets.QWidget()
         self.layout = QtWidgets.QVBoxLayout()
         self.w.setLayout(self.layout)
+        self.w.resizeEvent = self._onResize
 
         # using a stacked layout for the figure
         # allows for quick exchange between pre-rendered image-view vs matplotlib figure
@@ -134,11 +135,7 @@ class Animator:
                 self.prerender()
             if self.stack.currentWidget() != self.label:
                 self.stack.setCurrentWidget(self.label)
-            pm = QtGui.QPixmap('{}/{}.png'.format(self.dir, i))
-            pm = pm.scaled(self.label.width(), self.label.height(),
-                           Qt.KeepAspectRatio, Qt.SmoothTransformation)
-            self.label.setPixmap(pm)
-            self.label.setMinimumSize(1, 1)  # Allow downsizing the window.
+            self._renderFrameFromFile(i)
         else:
             if self.stack.currentWidget() != self.canvas:
                 self.stack.setCurrentWidget(self.canvas)
@@ -179,3 +176,18 @@ class Animator:
         self.visualize(initialFrame)
         self.slider.setValue(initialFrame)
         self.qApp.exec()
+
+    def _renderFrameFromFile(self, i=None):
+        """Render graphic from file given a frame number."""
+        if i == None:
+            i = self.slider.value()
+        pm = QtGui.QPixmap('{}/{}.png'.format(self.dir, i))
+        pm = pm.scaled(self.label.width(), self.label.height(),
+                       Qt.KeepAspectRatio, Qt.SmoothTransformation)
+        self.label.setPixmap(pm)
+        self.label.setMinimumSize(1, 1)  # Allow downsizing the window.
+
+    def _onResize(self, event):  # pylint: disable=unused-argument
+        """Re-render prerendered graphics on window resize."""
+        if self.prerender_checkbox.isChecked():
+            self._renderFrameFromFile()

--- a/example.py
+++ b/example.py
@@ -4,31 +4,35 @@ matplotlib.use("Qt5Agg")
 import matplotlib.pyplot as plt
 from MPLAnimator import Animator
 
+
 def naive_estimator(x, data, h):
-    n = sum(1 for d in data if x-h/2 < d <= x+h/2)
+    n = sum(1 for d in data if x - h / 2 < d <= x + h / 2)
     N = len(data)
-    return n/(N*h)
+    return n / (N * h)
+
 
 data = [0.5, 0.7, 0.8, 1.9, 2.4, 6.1, 6.2, 7.3]
 xs = np.arange(0, 8, 0.01)
 h = 2
 hist = [naive_estimator(x, data, h) for x in xs]
 
+
 def setup():
     plt.gcf()
     plt.suptitle("Naive Estimator for h = {}".format(h))
+
 
 def frame(i):
     plt.cla()
 
     # plot original data
     plt.plot(xs, hist)
-    plt.plot(data, [0]*len(data), 'xk')
+    plt.plot(data, [0] * len(data), 'xk')
     plt.axhline(0, color='k', linewidth=0.5)
 
     # calculate current interval
     x = i / 10
-    x1, x2 = x-h/2, x+h/2
+    x1, x2 = x - h / 2, x + h / 2
 
     # calculate relative width for visualization
     axis_to_data = plt.gca().transAxes + plt.gca().transData.inverted()
@@ -45,7 +49,7 @@ def frame(i):
 
     # highlight data in interval
     highlight_data = [d for d in data if x1 < d <= x2]
-    plt.plot(highlight_data, [0]*len(highlight_data), 'oC3')
+    plt.plot(highlight_data, [0] * len(highlight_data), 'oC3')
 
     plt.xlim(-0.5, 8.5)
 

--- a/example.py
+++ b/example.py
@@ -15,7 +15,7 @@ h = 2
 hist = [naive_estimator(x, data, h) for x in xs]
 
 def setup():
-    plt.gcf().set_size_inches(8,6)
+    plt.gcf()
     plt.suptitle("Naive Estimator for h = {}".format(h))
 
 def frame(i):
@@ -52,4 +52,4 @@ def frame(i):
 
 a = Animator(name='NaiveEstimator', setup_cb=setup)
 a.setFrameCallback(frame_cb=frame, max_frame=80)
-a.run(clear=False, prerendered=True)
+a.run(clear=False, prerendered=False)


### PR DESCRIPTION
Normal plots were already scaled before, this enables scaling also for pre-rendered graphics. Set to best quality, performance felt fine on my machine. Still: Pre-rendering after resizing the window to its desired size (probably full-screen) results in better quality, therefore this turns pre-rendering off by default. Also: Visuals should be centered now. Fixes #4 